### PR TITLE
Add support for selector $('input, select')

### DIFF
--- a/src/jquery.serializeToJSON.js
+++ b/src/jquery.serializeToJSON.js
@@ -129,43 +129,27 @@
 			},
 			
 			includeUncheckValues: function(selector, formAsArray){
-				let collection = $();
-				if(selector.length > 1 || (selector.length === 1 && selector[0].tagName !== 'FORM')){
-					selector.each(function(){
-						if(this.tagName === 'RADIO'){
-							collection = collection.add(this);
+				selector.map(function(){
+					// Can add propHook for "elements" to filter or add form elements
+					let elements = jQuery.prop( this, "elements" );
+					return elements ? jQuery.makeArray( elements ) : this;
+				}).each(function(){
+					if(this.tagName === 'RADIO'){
+						var isUncheckRadio = $("input[name='" + this.name + "']:radio:checked").length === 0;
+						if (isUncheckRadio)
+						{
+							formAsArray.push({
+								name: this.name,
+								value: null
+							});
 						}
-					});
-				}else{
-					collection = $(":radio", selector);
-				}
-				collection.each(function(){
-					var isUncheckRadio = $("input[name='" + this.name + "']:radio:checked").length === 0;
-					if (isUncheckRadio)
-					{
-						formAsArray.push({
-							name: this.name,
-							value: null
-						});
-					}
-				});
-
-				collection = $();
-				if(selector.length > 1 || (selector.length === 1 && selector[0].tagName !== 'FORM')){
-					selector.each(function(){
-						if(this.tagName === 'SELECT' && this.multiple === true){
-							collection = collection.add(this);
+					}else if(this.tagName === 'SELECT' && this.multiple === true) {
+						if ($(this).val() === null){
+							formAsArray.push({
+								name: this.name,
+								value: null
+							});
 						}
-					});
-				}else{
-					collection = $("select[multiple]", selector);
-				}
-				collection.each(function(){
-					if ($(this).val() === null){
-						formAsArray.push({
-							name: this.name,
-							value: null
-						});
 					}
 				});
 			},

--- a/src/jquery.serializeToJSON.js
+++ b/src/jquery.serializeToJSON.js
@@ -1,7 +1,7 @@
 /** 
  * serializeToJSON jQuery plugin
  * https://github.com/raphaelm22/jquery.serializeToJSON
- * @version: v1.4.1 (October, 2019)
+ * @version: v1.4.2 (June, 2025)
  * @author: Raphael Nunes
  *
  * Created by Raphael Nunes on 2015-08-28.
@@ -129,7 +129,17 @@
 			},
 			
 			includeUncheckValues: function(selector, formAsArray){
-				$(":radio", selector).each(function(){
+				let collection = $();
+				if(selector.length > 1 || (selector.length === 1 && selector[0].tagName !== 'FORM')){
+					selector.each(function(){
+						if(this.tagName === 'RADIO'){
+							collection = collection.add(this);
+						}
+					});
+				}else{
+					collection = $(":radio", selector);
+				}
+				collection.each(function(){
 					var isUncheckRadio = $("input[name='" + this.name + "']:radio:checked").length === 0;
 					if (isUncheckRadio)
 					{
@@ -139,8 +149,18 @@
 						});
 					}
 				});
-				
-				$("select[multiple]", selector).each(function(){					
+
+				collection = $();
+				if(selector.length > 1 || (selector.length === 1 && selector[0].tagName !== 'FORM')){
+					selector.each(function(){
+						if(this.tagName === 'SELECT' && this.multiple === true){
+							collection = collection.add(this);
+						}
+					});
+				}else{
+					collection = $("select[multiple]", selector);
+				}
+				collection.each(function(){
 					if ($(this).val() === null){
 						formAsArray.push({
 							name: this.name,


### PR DESCRIPTION
Updated `includeUncheckValues()` to support input selectors like $('input, select') just like `$.fn.serializeArray()` accepts.